### PR TITLE
Enable unsubscription for `useEvent`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.purs*
 /.psa*
 /.spago
+/dist/app.js

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>Halogen Hooks Extra - Examples</title>
+  </head>
+  <body>
+    <script src="./app.js" charset="utf-8"></script>
+  </body>
+</html>

--- a/examples.dhall
+++ b/examples.dhall
@@ -1,7 +1,7 @@
 let
  config = ./spago.dhall
 in { name = "my-project"
-   , dependencies = config.dependencies # [ ]
+   , dependencies = config.dependencies
    , packages = config.packages
    , sources = config.sources # [ "examples/**/*.purs" ]
    }

--- a/examples.dhall
+++ b/examples.dhall
@@ -1,0 +1,7 @@
+let
+ config = ./spago.dhall
+in { name = "my-project"
+   , dependencies = config.dependencies # [ ]
+   , packages = config.packages
+   , sources = config.sources # [ "examples/**/*.purs" ]
+   }

--- a/examples.dhall
+++ b/examples.dhall
@@ -1,7 +1,7 @@
 let
  config = ./spago.dhall
 in { name = "my-project"
-   , dependencies = config.dependencies
+   , dependencies = config.dependencies # [ "random" ]
    , packages = config.packages
    , sources = config.sources # [ "examples/**/*.purs" ]
    }

--- a/examples/Main.purs
+++ b/examples/Main.purs
@@ -1,0 +1,34 @@
+module Examples.Main where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Symbol (SProxy(..))
+import Effect (Effect)
+import Examples.UseEvent.UseLTEffectHandler as UseEvent
+import Halogen.Aff (awaitBody, runHalogenAff)
+import Halogen.HTML as HH
+import Halogen.Hooks as Hooks
+import Halogen.VDom.Driver (runUI)
+
+main :: Effect Unit
+main = runHalogenAff do
+  body <- awaitBody
+  runUI topComponent unit body
+  where
+    topComponent = Hooks.component \_ -> Hooks.pure render
+
+    render =
+      HH.div_
+        [ renderExample "useEvent" _useEvent UseEvent.component
+        ]
+
+
+    renderExample labelName sproxy comp =
+      HH.div_
+        [ HH.h2_ [ HH.text labelName ]
+        , HH.slot sproxy unit comp unit (const Nothing)
+        ]
+
+    -- sproxies
+    _useEvent = SProxy :: SProxy "useEvent"

--- a/examples/UseEvent/UseLTEffectHandler.purs
+++ b/examples/UseEvent/UseLTEffectHandler.purs
@@ -1,0 +1,77 @@
+module Examples.UseEvent.UseLTEffectHandler where
+
+import Prelude
+
+import Data.Const (Const)
+import Data.Foldable (for_)
+import Data.Maybe (Maybe(..))
+import Data.Tuple.Nested ((/\))
+import Effect.Aff (Aff)
+import Effect.Class.Console (log)
+import Effect.Ref as Ref
+import Halogen (liftEffect)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.Hooks (HookM, useRef, useState, useTickEffect)
+import Halogen.Hooks as Hooks
+
+component :: H.Component HH.HTML (Const Void) Unit Unit Aff
+component = Hooks.component \_ -> Hooks.do
+  _ /\ unsubscribeRef <- useRef Nothing
+  _ /\ callbackRef <- useRef Nothing
+
+  state /\ tState <- useState 0
+
+  let
+    pushValueAndTriggerCallback :: Int -> HookM _ _ Aff Unit
+    pushValueAndTriggerCallback value = do
+      mbCallback <- liftEffect $ Ref.read callbackRef
+      for_ mbCallback \callback -> do
+        callback value
+
+    setCallback callback =
+      liftEffect $ Ref.write callback callbackRef
+
+  -- at some point in code, we trigger the callback via
+  -- `pushValueAndTriggerCallback`
+
+  -- Here, we set a callback that will handle the events emitted.
+  -- We chose to use the `useTickEffect` version, but we could
+  -- could have used the `useLifecycleEffect`
+  Hooks.captures { state } useTickEffect do
+    setCallback $ Just \i -> do
+      -- here, we handle the event emitted
+      liftEffect $ log $ "New value is: " <> show i
+
+      -- here, we can set up some resources and do various things
+      -- (code is not shown; use your imagination)
+
+      -- here, we store the code necessary for unsubscribing
+      let unsubscribeCode = pure unit -- unsubscribe
+      mbUnsubscribe <- liftEffect $ Ref.read unsubscribeRef
+      case mbUnsubscribe of
+        Nothing -> do
+          -- This is the first time we're running this, so
+          -- write the unsubscribe code to a Ref,
+          -- so that we can run it later
+          liftEffect $ Ref.write (Just unsubscribeCode) unsubscribeRef
+        _ -> do
+          -- no need to store unsubscriber because
+          -- 1. it's already been stored (i.e. this is the 2+ run)
+          -- 2. we didn't setup any resources that need to be cleaned up later
+          --     (i.e. this is purely an event handler)
+          pure unit
+
+    pure $ Just do
+      -- Here, we read the Ref to get back the unsubscribe code,
+      -- run it, and then set the `Ref` back to `Nothing`,
+      -- so that future subscribes will work.
+      mbUnsubscribe <- liftEffect $ Ref.read unsubscribeRef
+      case mbUnsubscribe of
+        Just unsubscribe' -> do
+          unsubscribe'
+          liftEffect $ Ref.write Nothing unsubscribeRef
+        _ -> do
+          pure unit
+
+  Hooks.pure $ HH.text "example"

--- a/examples/UseEvent/UseLTEffectHandler.purs
+++ b/examples/UseEvent/UseLTEffectHandler.purs
@@ -31,6 +31,10 @@ component = Hooks.component \_ -> Hooks.do
   -- We chose to use the `useTickEffect` version, but we could
   -- could have used the `useLifecycleEffect`
   Hooks.captures { state } useTickEffect do
+
+    -- Note: if we don't need to unsubscribe from anything,
+    -- we can ignore the `unsubscribeCallback`. For example
+    --  changes.setCallback $ Just \_ i -> do
     changes.setCallback $ Just \unsubscribeCallback i -> do
       -- here, we handle the event emitted
       liftEffect $ log $ "New value is: " <> show i

--- a/examples/UseEvent/UseLTEffectHandler.purs
+++ b/examples/UseEvent/UseLTEffectHandler.purs
@@ -3,13 +3,16 @@ module Examples.UseEvent.UseLTEffectHandler where
 import Prelude
 
 import Data.Const (Const)
+import Data.Int (even)
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
 import Effect.Aff (Aff)
 import Effect.Class.Console (log)
+import Effect.Random (randomInt)
 import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
 import Halogen.Hooks (HookM, useState, useTickEffect)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Extra.Hooks.UseEvent (useEvent)
@@ -37,7 +40,7 @@ component = Hooks.component \_ -> Hooks.do
     --  changes.setCallback $ Just \_ i -> do
     changes.setCallback $ Just \unsubscribeCallback i -> do
       -- here, we handle the event emitted
-      liftEffect $ log $ "New value is: " <> show i
+      liftEffect $ log $ "Handling event. New value is: " <> show i
 
       -- here, we can set up some resources and do various things
 
@@ -49,4 +52,21 @@ component = Hooks.component \_ -> Hooks.do
     pure $ Just do
       changes.unsubscribe
 
-  Hooks.pure $ HH.text "example"
+  Hooks.pure $
+    HH.div_
+      [ HH.button
+        [ HE.onClick \_ -> Just do
+          i <- liftEffect $ randomInt 0 10
+          pushValueAndTriggerCallback i
+        ]
+        [ HH.text "Click to push a new int value to callback"
+        ]
+      , HH.br_
+      , HH.button
+        [ HE.onClick \_ -> Just do
+          Hooks.modify_ tState \s -> s + 1
+        ]
+        [ HH.text "Click to change the state value, which will unsubscribe \
+                  \prior handler and resubscribe using new handler"
+        ]
+      ]

--- a/examples/UseEvent/UseLTEffectHandler.purs
+++ b/examples/UseEvent/UseLTEffectHandler.purs
@@ -26,43 +26,28 @@ component = Hooks.component \_ -> Hooks.do
     pushValueAndTriggerCallback :: Int -> HookM _ _ Aff Unit
     pushValueAndTriggerCallback value = do
       mbCallback <- liftEffect $ Ref.read callbackRef
+      let
+        setupUnsubscribeCallback = \unsubscribeCode -> do
+          mbUnsubscribe <- liftEffect $ Ref.read unsubscribeRef
+          case mbUnsubscribe of
+            Nothing -> do
+              -- This is the first time we're running this, so
+              -- write the unsubscribe code to a Ref,
+              -- so that we can run it later
+              liftEffect $ Ref.write (Just unsubscribeCode) unsubscribeRef
+            _ -> do
+              -- no need to store unsubscriber because
+              -- 1. it's already been stored (i.e. this is the 2+ run)
+              -- 2. we didn't setup any resources that need to be cleaned up later
+              --     (i.e. this is purely an event handler)
+              pure unit
       for_ mbCallback \callback -> do
-        callback value
+        callback setupUnsubscribeCallback value
 
     setCallback callback =
       liftEffect $ Ref.write callback callbackRef
 
-  -- at some point in code, we trigger the callback via
-  -- `pushValueAndTriggerCallback`
-
-  -- Here, we set a callback that will handle the events emitted.
-  -- We chose to use the `useTickEffect` version, but we could
-  -- could have used the `useLifecycleEffect`
-  Hooks.captures { state } useTickEffect do
-    setCallback $ Just \i -> do
-      -- here, we handle the event emitted
-      liftEffect $ log $ "New value is: " <> show i
-
-      -- here, we can set up some resources and do various things
-      -- (code is not shown; use your imagination)
-
-      -- here, we store the code necessary for unsubscribing
-      let unsubscribeCode = pure unit -- unsubscribe
-      mbUnsubscribe <- liftEffect $ Ref.read unsubscribeRef
-      case mbUnsubscribe of
-        Nothing -> do
-          -- This is the first time we're running this, so
-          -- write the unsubscribe code to a Ref,
-          -- so that we can run it later
-          liftEffect $ Ref.write (Just unsubscribeCode) unsubscribeRef
-        _ -> do
-          -- no need to store unsubscriber because
-          -- 1. it's already been stored (i.e. this is the 2+ run)
-          -- 2. we didn't setup any resources that need to be cleaned up later
-          --     (i.e. this is purely an event handler)
-          pure unit
-
-    pure $ Just do
+    unsubscribe = do
       -- Here, we read the Ref to get back the unsubscribe code,
       -- run it, and then set the `Ref` back to `Nothing`,
       -- so that future subscribes will work.
@@ -73,5 +58,26 @@ component = Hooks.component \_ -> Hooks.do
           liftEffect $ Ref.write Nothing unsubscribeRef
         _ -> do
           pure unit
+
+  -- at some point in code, we trigger the callback via
+  -- `pushValueAndTriggerCallback`
+
+  -- Here, we set a callback that will handle the events emitted.
+  -- We chose to use the `useTickEffect` version, but we could
+  -- could have used the `useLifecycleEffect`
+  Hooks.captures { state } useTickEffect do
+    setCallback $ Just \unsubscribeCallback i -> do
+      -- here, we handle the event emitted
+      liftEffect $ log $ "New value is: " <> show i
+
+      -- here, we can set up some resources and do various things
+
+      -- here, we store the code necessary for unsubscribing
+      unsubscribeCallback do
+        let unsubscribe' = pure unit -- unsubscribe
+        unsubscribe'
+
+    pure $ Just do
+      unsubscribe
 
   Hooks.pure $ HH.text "example"

--- a/examples/UseEvent/UseLTEffectHandler.purs
+++ b/examples/UseEvent/UseLTEffectHandler.purs
@@ -3,61 +3,26 @@ module Examples.UseEvent.UseLTEffectHandler where
 import Prelude
 
 import Data.Const (Const)
-import Data.Foldable (for_)
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
 import Effect.Aff (Aff)
 import Effect.Class.Console (log)
-import Effect.Ref as Ref
 import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
-import Halogen.Hooks (HookM, useRef, useState, useTickEffect)
+import Halogen.Hooks (HookM, useState, useTickEffect)
 import Halogen.Hooks as Hooks
+import Halogen.Hooks.Extra.Hooks.UseEvent (useEvent)
 
 component :: H.Component HH.HTML (Const Void) Unit Unit Aff
 component = Hooks.component \_ -> Hooks.do
-  _ /\ unsubscribeRef <- useRef Nothing
-  _ /\ callbackRef <- useRef Nothing
+  changes <- useEvent
 
   state /\ tState <- useState 0
 
   let
     pushValueAndTriggerCallback :: Int -> HookM _ _ Aff Unit
-    pushValueAndTriggerCallback value = do
-      mbCallback <- liftEffect $ Ref.read callbackRef
-      let
-        setupUnsubscribeCallback = \unsubscribeCode -> do
-          mbUnsubscribe <- liftEffect $ Ref.read unsubscribeRef
-          case mbUnsubscribe of
-            Nothing -> do
-              -- This is the first time we're running this, so
-              -- write the unsubscribe code to a Ref,
-              -- so that we can run it later
-              liftEffect $ Ref.write (Just unsubscribeCode) unsubscribeRef
-            _ -> do
-              -- no need to store unsubscriber because
-              -- 1. it's already been stored (i.e. this is the 2+ run)
-              -- 2. we didn't setup any resources that need to be cleaned up later
-              --     (i.e. this is purely an event handler)
-              pure unit
-      for_ mbCallback \callback -> do
-        callback setupUnsubscribeCallback value
-
-    setCallback callback =
-      liftEffect $ Ref.write callback callbackRef
-
-    unsubscribe = do
-      -- Here, we read the Ref to get back the unsubscribe code,
-      -- run it, and then set the `Ref` back to `Nothing`,
-      -- so that future subscribes will work.
-      mbUnsubscribe <- liftEffect $ Ref.read unsubscribeRef
-      case mbUnsubscribe of
-        Just unsubscribe' -> do
-          unsubscribe'
-          liftEffect $ Ref.write Nothing unsubscribeRef
-        _ -> do
-          pure unit
+    pushValueAndTriggerCallback = changes.push
 
   -- at some point in code, we trigger the callback via
   -- `pushValueAndTriggerCallback`
@@ -66,7 +31,7 @@ component = Hooks.component \_ -> Hooks.do
   -- We chose to use the `useTickEffect` version, but we could
   -- could have used the `useLifecycleEffect`
   Hooks.captures { state } useTickEffect do
-    setCallback $ Just \unsubscribeCallback i -> do
+    changes.setCallback $ Just \unsubscribeCallback i -> do
       -- here, we handle the event emitted
       liftEffect $ log $ "New value is: " <> show i
 
@@ -78,6 +43,6 @@ component = Hooks.component \_ -> Hooks.do
         unsubscribe'
 
     pure $ Just do
-      unsubscribe
+      changes.unsubscribe
 
   Hooks.pure $ HH.text "example"

--- a/packages.dhall
+++ b/packages.dhall
@@ -121,7 +121,8 @@ let additions =
 let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200404/packages.dhall sha256:f239f2e215d0cbd5c203307701748581938f74c4c78f4aeffa32c11c131ef7b6
 
-let overrides = {=}
+let overrides =
+  { halogen-hooks = upstream.halogen-hooks // { version = "v0.2.0" } }
 
 let additions = {=}
 

--- a/src/Halogen/Hooks/Extra/Actions/Events.purs
+++ b/src/Halogen/Hooks/Extra/Actions/Events.purs
@@ -9,30 +9,30 @@ import Web.UIEvent.KeyboardEvent as KE
 import Web.UIEvent.MouseEvent as ME
 
 preventDefault'
-  :: forall slots output m
+  :: forall m
    . MonadEffect m
   => Event.Event
-  -> HookM slots output m Unit
+  -> HookM m Unit
 preventDefault' ev = liftEffect (Event.preventDefault ev)
 
 preventDefault
-  :: forall event slots output m
+  :: forall event m
    . MonadEffect m
   => (event -> Event.Event)
   -> event
-  -> HookM slots output m Unit
+  -> HookM m Unit
 preventDefault toEvent ev = preventDefault' (toEvent ev)
 
 preventMouseEvent
-  :: forall slots output m
+  :: forall m
    . MonadEffect m
   => ME.MouseEvent
-  -> HookM slots output m Unit
+  -> HookM m Unit
 preventMouseEvent = preventDefault ME.toEvent
 
 preventKeyEvent
-  :: forall slots output m
+  :: forall m
    . MonadEffect m
   => KE.KeyboardEvent
-  -> HookM slots output m Unit
+  -> HookM m Unit
 preventKeyEvent = preventDefault KE.toEvent

--- a/src/Halogen/Hooks/Extra/Hooks/UseDebouncer.purs
+++ b/src/Halogen/Hooks/Extra/Hooks/UseDebouncer.purs
@@ -55,11 +55,11 @@ type Debouncer =
 -- |      ]
 -- | ```
 useDebouncer
-  :: forall slots output m a
+  :: forall m a
    . MonadAff m
   => Milliseconds
-  -> (a -> HookM slots output m Unit)
-  -> Hook slots output m (UseDebouncer a) (a -> HookM slots output m Unit)
+  -> (a -> HookM m Unit)
+  -> Hook m (UseDebouncer a) (a -> HookM m Unit)
 useDebouncer ms fn = Hooks.wrap Hooks.do
   _ /\ debounceRef <- Hooks.useRef Nothing
   _ /\ valRef <- Hooks.useRef Nothing


### PR DESCRIPTION
`useEvent` is a bit cryptic now, so I added an example that showed how I got to this idea. If you follow along the commits in the examples folder, it should be straight-forward as to how I got this implementation.

I think there's a few more things to be desired after this gets merged:
- making it possible to add multiple handlers using the same `useEvent`, which can unsubscribe independently from one another (e.g. if one gets run in one `useTickEffect` with dependencies while another runs in another `useTickEffect` with other dependencies).
- ~using one Ref for both the valueCallback and the unsubscribeCallback rather than 1 Ref for each.~ Done in latest commits.

Also, I wonder if this implementation could be refactored to include a fork of `purescript-events` where that library's callbacks can be run in a monad other than `Effect` as long as it has a `MonadEffect` constrant.