### PR TITLE
Update halogen-hooks v0.3.0; add useGet; refactor useDebouncer

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -122,7 +122,7 @@ let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200404/packages.dhall sha256:f239f2e215d0cbd5c203307701748581938f74c4c78f4aeffa32c11c131ef7b6
 
 let overrides =
-  { halogen-hooks = upstream.halogen-hooks // { version = "v0.2.0" } }
+  { halogen-hooks = upstream.halogen-hooks // { version = "v0.3.0" } }
 
 let additions = {=}
 

--- a/src/Halogen/Hooks/Extra/Hooks.purs
+++ b/src/Halogen/Hooks/Extra/Hooks.purs
@@ -1,0 +1,9 @@
+-- | Reexports all Hooks defined in this repository.
+module Halogen.Hooks.Extra.Hooks
+  ( module Exports
+
+  ) where
+
+import Halogen.Hooks.Extra.Hooks.UseDebouncer (useDebouncer) as Exports
+import Halogen.Hooks.Extra.Hooks.UseGet (useGet) as Exports
+import Halogen.Hooks.Extra.Hooks.UseEvent (useEvent) as Exports

--- a/src/Halogen/Hooks/Extra/Hooks.purs
+++ b/src/Halogen/Hooks/Extra/Hooks.purs
@@ -1,9 +1,10 @@
 -- | Reexports all Hooks defined in this repository.
 module Halogen.Hooks.Extra.Hooks
-  ( module Exports
-
+  ( module Halogen.Hooks.Extra.Hooks.UseDebouncer
+  , module Halogen.Hooks.Extra.Hooks.UseGet
+  , module Halogen.Hooks.Extra.Hooks.UseEvent
   ) where
 
-import Halogen.Hooks.Extra.Hooks.UseDebouncer (useDebouncer) as Exports
-import Halogen.Hooks.Extra.Hooks.UseGet (useGet) as Exports
-import Halogen.Hooks.Extra.Hooks.UseEvent (useEvent) as Exports
+import Halogen.Hooks.Extra.Hooks.UseDebouncer (UseDebouncer(..), useDebouncer)
+import Halogen.Hooks.Extra.Hooks.UseGet (UseGet(..), useGet)
+import Halogen.Hooks.Extra.Hooks.UseEvent (UseEvent(..), useEvent)

--- a/src/Halogen/Hooks/Extra/Hooks.purs
+++ b/src/Halogen/Hooks/Extra/Hooks.purs
@@ -7,4 +7,4 @@ module Halogen.Hooks.Extra.Hooks
 
 import Halogen.Hooks.Extra.Hooks.UseDebouncer (UseDebouncer, useDebouncer)
 import Halogen.Hooks.Extra.Hooks.UseGet (UseGet, useGet)
-import Halogen.Hooks.Extra.Hooks.UseEvent (UseEvent, useEvent)
+import Halogen.Hooks.Extra.Hooks.UseEvent (UseEvent, UseEventApi, useEvent)

--- a/src/Halogen/Hooks/Extra/Hooks.purs
+++ b/src/Halogen/Hooks/Extra/Hooks.purs
@@ -5,6 +5,6 @@ module Halogen.Hooks.Extra.Hooks
   , module Halogen.Hooks.Extra.Hooks.UseEvent
   ) where
 
-import Halogen.Hooks.Extra.Hooks.UseDebouncer (UseDebouncer(..), useDebouncer)
-import Halogen.Hooks.Extra.Hooks.UseGet (UseGet(..), useGet)
-import Halogen.Hooks.Extra.Hooks.UseEvent (UseEvent(..), useEvent)
+import Halogen.Hooks.Extra.Hooks.UseDebouncer (UseDebouncer, useDebouncer)
+import Halogen.Hooks.Extra.Hooks.UseGet (UseGet, useGet)
+import Halogen.Hooks.Extra.Hooks.UseEvent (UseEvent, useEvent)

--- a/src/Halogen/Hooks/Extra/Hooks/UseEvent.purs
+++ b/src/Halogen/Hooks/Extra/Hooks/UseEvent.purs
@@ -1,7 +1,7 @@
 module Halogen.Hooks.Extra.Hooks.UseEvent
   ( useEvent
   , UseEvent
-  , EventApi
+  , UseEventApi
   )
   where
 
@@ -32,7 +32,7 @@ newtype UseEvent m a hooks =
 derive instance newtypeUseEvent :: Newtype (UseEvent m a hooks) _
 
 -- | For proper usage, see the docs for `useEvent`.
-type EventApi m a =
+type UseEventApi m a =
   { push :: a -> HookM m Unit
   , setCallback
       :: Maybe
@@ -132,7 +132,7 @@ type EventApi m a =
 useEvent :: forall m a hooks
    . MonadEffect m
   => Hooked m hooks (UseEvent m a hooks)
-      (EventApi m a)
+      (UseEventApi m a)
 useEvent = Hooks.wrap Hooks.do
   -- valueCB = the callback to run when a new event is pushed
   -- unsubscribeCB = callback to run when unsubscribing

--- a/src/Halogen/Hooks/Extra/Hooks/UseGet.purs
+++ b/src/Halogen/Hooks/Extra/Hooks/UseGet.purs
@@ -1,0 +1,35 @@
+-- | Idea and implementation by Thomas Honeyman. This was copied
+-- | over from the Halogen Hooks repository's Examples folder.
+module Halogen.Hooks.Extra.Hooks.UseGet
+  ( useGet
+  , UseGet
+  )
+  where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Data.Tuple.Nested ((/\))
+import Effect.Class (class MonadEffect, liftEffect)
+import Effect.Ref as Ref
+import Halogen.Hooks (Hook, HookM, UseEffect, UseRef)
+import Halogen.Hooks as Hooks
+
+newtype UseGet a hooks = UseGet (UseEffect (UseRef a hooks))
+
+derive instance newtypeUseGet :: Newtype (UseGet a hooks) _
+
+useGet
+  :: forall m a
+   . MonadEffect m
+  => a
+  -> Hook m (UseGet a) (HookM m a)
+useGet latest = Hooks.wrap Hooks.do
+  _ /\ ref <- Hooks.useRef latest
+
+  Hooks.captures {} Hooks.useTickEffect do
+    liftEffect $ Ref.write latest ref
+    pure Nothing
+
+  Hooks.pure (liftEffect $ Ref.read ref)

--- a/src/Halogen/Hooks/Extra/Hooks/UseGet.purs
+++ b/src/Halogen/Hooks/Extra/Hooks/UseGet.purs
@@ -20,6 +20,56 @@ newtype UseGet a hooks = UseGet (UseEffect (UseRef a hooks))
 
 derive instance newtypeUseGet :: Newtype (UseGet a hooks) _
 
+-- | Use this hook when you wish to refer to a state value or the input value
+-- | in a `useLifecycleEffect`/`useTickEffect`'s
+-- | cleanup/finalizer/unsubscribe computation. If you don't use this hook
+-- | in such situations, you may refer to what the value used to be
+-- | (a stale value), not what the value is now. Here's what would happen
+-- | if we did not use this hook:
+-- | ```
+-- | myComponent :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
+-- | myComponent = Hooks.component \_ _ -> Hooks.do
+-- |   thisIsFive_NotSix /\ modifyState <- Hooks.useState 5
+-- |
+-- |   Hooks.captures {} Hooks.useTickEffect do
+-- |     -- The `thisIsFive_NotSix` state reference is currently `5` and
+-- |     -- is up-to-date because this effect body runs immediately
+-- |     -- after the Hook evaluation in which it is defined.
+-- |     -- Thus, this will print "5" to the console.
+-- |     logShow thisIsFive_NotSix
+-- |
+-- |     -- Now we change the value to 6
+-- |     modifyState (_ + 1)
+-- |
+-- |     pure $ Just $ do
+-- |       -- The effect cleanup, however, will not run after the Hook
+-- |       -- evaluation in which it is defined. Thus, the `thisIsFive_NotSix`
+-- |       -- state reference is still `5` even though we previously
+-- |       -- updated the real value to 6.
+-- |       -- Thus, this will print "5" to the console when it should print "6".
+-- |       logShow thisIsFive_NotSix
+-- | ```
+-- | To ensure we refer to the latest value and not a stale one, we use
+-- | this hook to do so.
+-- | ```
+-- | myComponent :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
+-- | myComponent = Hooks.component \_ _ -> Hooks.do
+-- |   thisIsFive_NotSix /\ modifyState <- Hooks.useState 5
+-- |
+-- |   -- This returns a function to get the latest state/input value.
+-- |   getState <- useGet thisIsFive_NotSix
+-- |
+-- |   Hooks.captures {} Hooks.useTickEffect do
+-- |     logShow thisIsFive_NotSix
+-- |
+-- |     modifyState (_ + 1)
+-- |
+-- |     pure $ Just $ do
+-- |       -- Now we get the latest value rather than using the stale value.
+-- |       -- This correctly prints "6".
+-- |       thisIsSix_NotFive <- getState
+-- |       logShow thisIsSix_NotFive
+-- | ```
 useGet
   :: forall m a
    . MonadEffect m

--- a/src/Halogen/Hooks/Extra/Hooks/UseGet.purs
+++ b/src/Halogen/Hooks/Extra/Hooks/UseGet.purs
@@ -20,12 +20,16 @@ newtype UseGet a hooks = UseGet (UseEffect (UseRef a hooks))
 
 derive instance newtypeUseGet :: Newtype (UseGet a hooks) _
 
--- | Use this hook when you wish to refer to a state value or the input value
--- | in a `useLifecycleEffect`/`useTickEffect`'s
--- | cleanup/finalizer/unsubscribe computation. If you don't use this hook
--- | in such situations, you may refer to what the value used to be
--- | (a stale value), not what the value is now. Here's what would happen
--- | if we did not use this hook:
+-- | Use this hook when you wish to ensure that your reference to a state
+-- | value or the component's input is not "stale" or outdated. Usually, this
+-- | happens in when you define a computation in one "Hook evaluation cycle,"
+-- | but you do not run the computation until a future "Hook evaluation cycle."
+-- | This typically occurs when running a `useLifecycleEffect`/`useTickEffect`'s
+-- | cleanup/finalizer/unsubscribe computation.
+-- |
+-- | Let's see an example of an effect's finalizer referring to a stale value
+-- | in code. If you don't use `useGet` in this situation, you will refer to
+-- | what the value used to be (a stale value), not what the value is now:
 -- | ```
 -- | myComponent :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
 -- | myComponent = Hooks.component \_ _ -> Hooks.do


### PR DESCRIPTION
`useDebouncer` was refactored to only use one `Ref` on the principle that using less hooks is likely more performant. 

I also added the `useGet` example in the halogen-hooks repo's examples folder. I think Thomas should add stand-alone docs, but that can be done in a later release.

Lastly, this PR now adds a module that reexports all hooks, so that the number of lines of imports decreases.

**Edit:** also fixes #1 